### PR TITLE
Fix ReferenceError creating a new board in Firefox

### DIFF
--- a/client/trello/src/app/components/BoardItem/BoardItem.js
+++ b/client/trello/src/app/components/BoardItem/BoardItem.js
@@ -121,7 +121,7 @@ export default function BoardItem(props) {
     return (
       <div
         className={ `${getClassName()}-Tile-Add` }
-        onClick={ () => openModal(event) }
+        onClick={ openModal }
       >
         <span>{ boardName }</span>
       </div>


### PR DESCRIPTION
ReferenceError: event is not defined

```
onClick webpack:///./src/app/components/BoardItem/BoardItem.js?:181:11
	bound onClick self-hosted
	ReactErrorUtils.invokeGuardedCallback webpack:///./~/react-dom/lib/ReactErrorUtils.js?:70:7
	executeDispatch webpack:///./~/react-dom/lib/EventPluginUtils.js?:85:5
	executeDispatchesInOrder webpack:///./~/react-dom/lib/EventPluginUtils.js?:105:7
	executeDispatchesAndRelease webpack:///./~/react-dom/lib/EventPluginHub.js?:43:5
	executeDispatchesAndReleaseTopLevel webpack:///./~/react-dom/lib/EventPluginHub.js?:54:10
	forEach self-hosted
	forEachAccumulated webpack:///./~/react-dom/lib/forEachAccumulated.js?:24:5
	EventPluginHub.processEventQueue webpack:///./~/react-dom/lib/EventPluginHub.js?:257:7
	runEventQueueInBatch webpack:///./~/react-dom/lib/ReactEventEmitterMixin.js?:17:3
	ReactEventEmitterMixin.handleTopLevel webpack:///./~/react-dom/lib/ReactEventEmitterMixin.js?:28:5
	handleTopLevelImpl webpack:///./~/react-dom/lib/ReactEventListener.js?:72:5
	TransactionImpl.perform webpack:///./~/react-dom/lib/Transaction.js?:140:13
	ReactDefaultBatchingStrategy.batchedUpdates webpack:///./~/react-dom/lib/ReactDefaultBatchingStrategy.js?:62:14
	batchedUpdates webpack:///./~/react-dom/lib/ReactUpdates.js?:97:10
	ReactEventListener.dispatchEvent webpack:///./~/react-dom/lib/ReactEventListener.js?:147:7
	bound  self-hosted
```